### PR TITLE
Timeout after a default of 360 seconds

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "leadconduit-zillow": "~0.0.3",
     "leadconduit-zipcodes": "^0.1.0",
     "lodash": "^3.2.0",
-    "request": "^2.51.0",
+    "request": "^2.67.0",
     "underscore.string": "^2.3.3"
   },
   "devDependencies": {
@@ -73,6 +73,6 @@
     "coffee-script": "^1.8.0",
     "leadconduit-types": "^3.2.3",
     "mocha": "^1.21.4",
-    "nock": "^0.56.0"
+    "nock": "^5.2.1"
   }
 }

--- a/spec/handle-spec.coffee
+++ b/spec/handle-spec.coffee
@@ -11,6 +11,9 @@ describe 'Handle', ->
       .post '/'
       .reply 200, outcome: 'success'
 
+  afterEach ->
+    nock.cleanAll()
+
   after ->
     integrations.deregister 'test'
 

--- a/spec/timeout-spec.coffee
+++ b/spec/timeout-spec.coffee
@@ -1,0 +1,43 @@
+assert = require('chai').assert
+nock = require('nock')
+types = require('leadconduit-types')
+integrations = require('../src/index')
+
+describe 'Timeout', ->
+
+  before ->
+    integrations.register 'test',
+      request: ->
+        url: 'http://externalservice'
+        method: 'POST'
+      response: (vars, req, res) ->
+        JSON.parse(res.body)
+
+  after ->
+    integrations.deregister 'test'
+
+  afterEach ->
+    nock.cleanAll()
+
+   it 'should return error on delay', (done) ->
+    nock 'http://externalservice'
+      .post '/'
+      .socketDelay 400000
+      .reply 200, outcome: 'success'
+
+    integrations.lookup('test').handle {}, (err, event) ->
+      assert err
+      assert.equal err.code, 'ESOCKETTIMEDOUT'
+      done()
+
+
+  it 'should not return error when no delay', (done) ->
+    nock 'http://externalservice'
+    .post '/'
+    .reply 200, outcome: 'success'
+
+    integrations.lookup('test').handle {}, (err, event) ->
+      assert.isNull err
+      assert event
+      done()
+

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -126,6 +126,7 @@ generateHandle = (outbound) ->
     # Protect against the request module throwing an error when bad options are specified
     makeRequest = (options, cb) ->
       options.url = options.url?.valueOf()
+      options.timeout ?= 360000 # Same as the load balancer timeout
       return cb(new Error('request missing URL')) unless options.url?.trim()
       return cb(new Error('request missing method')) unless options.method?.trim()
       try


### PR DESCRIPTION
Sets a default 360 second timeout. This impacts all integrations that implement the `request()` and `response()` functions. Integrations that implement the `handle()` function are responsible for setting the timeout.