### PR TITLE
All outbound integration modules publish the timeout_seconds request variable

### DIFF
--- a/spec/modules-spec.coffee
+++ b/spec/modules-spec.coffee
@@ -1,3 +1,4 @@
+_ = require('lodash')
 assert = require('chai').assert
 integrations = require('../src/index')
 
@@ -14,3 +15,11 @@ describe 'Modules', ->
 
   it 'should find private @activeprospect module by id', ->
     assert integrations.lookup('leadconduit-360.outbound.vendor_lookup')
+
+  it 'should provide timeout seconds', ->
+    requestVars = integrations.modules['leadconduit-default.outbound'].request_variables
+    assert.deepEqual _.find(requestVars, name: 'timeout_seconds'),
+      name: 'timeout_seconds'
+      type: 'number'
+      description: 'Produce an "error" outcome if the server fails to respond within this number of seconds (default: 360)'
+      required: false

--- a/spec/timeout-spec.coffee
+++ b/spec/timeout-spec.coffee
@@ -91,3 +91,4 @@ describe 'Timeout', ->
     integrations.lookup('test').handle timeout_seconds: 'donkey', (err) ->
       assert.equal err.message, 'request timeout must be a number'
       done()
+

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -95,8 +95,12 @@ generateModule = (id, integration) ->
     else if (modulePath.match(/outbound/))
       'outbound';
 
-  requestVariables = integration?.requestVariables?() ? integration.request?.variables?()
-  responseVariables = integration?.responseVariables?() ? integration.response?.variables?()
+  requestVariables = integration?.requestVariables?() ? integration.request?.variables?() ? []
+  responseVariables = integration?.responseVariables?() ? integration.response?.variables?() ? []
+
+  # Add the timeout_seconds request variable
+  if type == 'outbound' and !_.find(requestVariables, name: 'timeout_seconds')
+    requestVariables.push(name: 'timeout_seconds', type: 'number', description: 'Produce an "error" outcome if the server fails to respond within this number of seconds (default: 360)', required: false)
 
   modules[id] =
     id: id


### PR DESCRIPTION
The default `handle()` function added by the `generateHandle` function supports timeouts. And integrations which implement their own `handle()` function must also. So this change simple ensures that outbound request variables always contain the `timeout_seconds` variable.