### PR TITLE
Extract function for ensuring a valid timeout

### DIFF
--- a/spec/timeout-spec.coffee
+++ b/spec/timeout-spec.coffee
@@ -82,13 +82,13 @@ describe 'Timeout', ->
       done()
 
 
-  it 'should return error when request function returns non-number', (done) ->
+  it 'should not return error when request function returns non-number', (done) ->
     nock 'http://externalservice'
       .post '/'
-      .socketDelay 10000
       .reply 200, outcome: 'success'
 
-    integrations.lookup('test').handle timeout_seconds: 'donkey', (err) ->
-      assert.equal err.message, 'request timeout must be a number'
+    integrations.lookup('test').handle timeout_seconds: 'donkey', (err, event) ->
+      assert.isNull err
+      assert event
       done()
 

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -78,6 +78,22 @@ lookup = (moduleId) ->
   integrations[moduleId]
 
 
+#
+# Public: ensure that timeout is a primitive number somewhere between minTimeout and maxTimeout
+#
+ensureTimeout = (timeout) ->
+  timeout = new Number(timeout).valueOf()
+
+  # Return default maximum if the timeout isn't a finite number
+  return maxTimeout unless _.isFinite(timeout)
+
+  # Ensure that timeout is set somewhere between minTimeout and maxTimeout
+  return maxTimeout if timeout > maxTimeout
+  return minTimeout if timeout < minTimeout
+
+  timeout
+
+
 
 #
 # Helpers ----------------------------------------------------------------
@@ -132,17 +148,11 @@ generateHandle = (outbound) ->
     # Protect against the request module throwing an error when bad options are specified
     makeRequest = (options, cb) ->
       options.url = options.url?.valueOf()
-      options.timeout ?= vars.timeout_seconds ? maxTimeout
       return cb(new Error('request missing URL')) unless options.url?.trim()
       return cb(new Error('request missing method')) unless options.method?.trim()
-      return cb(new Error('request timeout must be a number')) unless _.isFinite(options.timeout)
 
-      # Ensure that timeout is set somewhere between minTimeout and maxTimeout
-      options.timeout = maxTimeout if options.timeout > maxTimeout
-      options.timeout = minTimeout if options.timeout < minTimeout
-
-      # Convert timeout seconds to milliseconds
-      options.timeout = options.timeout * 1000
+      # Ensure that timeout is set somewhere between minTimeout and maxTimeout and convert to milliseconds
+      options.timeout = ensureTimeout(options.timeout ? vars.timeout_seconds) * 1000
 
       try
         request options, cb
@@ -261,6 +271,7 @@ empty = (str) ->
   !!str?.trim()
 
 
+
 #
 # Module -----------------------------------------------------------------
 #
@@ -277,3 +288,4 @@ module.exports =
   lookup: lookup
   maxTimeout: maxTimeout
   minTimeout: minTimeout
+  ensureTimeout: ensureTimeout


### PR DESCRIPTION
Also, don't throw an error when timeout is invalid. In retrospect, this seems like a bad choice. If a user puts something invalid in the timeout field, this could cause mishandled leads. Instead of this, default to the max timeout.