### PR TITLE
update leadconduit-types semver from ^3.2.3 to ^4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "devDependencies": {
     "chai": "^1.10.0",
     "coffee-script": "^1.8.0",
-    "leadconduit-types": "^3.2.3",
+    "leadconduit-types": "^4.5.0",
     "mocha": "^1.21.4",
     "nock": "^5.2.1"
   }


### PR DESCRIPTION
LGTY? I'll update the commit message once approved. It should say update leadconduit-types semver from ^3.2.3 to ^4.5.0