### PR TITLE
Package name

### DIFF
--- a/spec/modules-spec.coffee
+++ b/spec/modules-spec.coffee
@@ -9,7 +9,6 @@ describe 'Modules', ->
       assert.equal integrations.modules[id].id, id
       assert.match integrations.modules[id].id, /[-.]/
 
-
   it 'should lookup by module id', ->
     assert integrations.lookup('leadconduit-default.inbound')
 
@@ -23,3 +22,19 @@ describe 'Modules', ->
       type: 'number'
       description: 'Produce an "error" outcome if the server fails to respond within this number of seconds (default: 360)'
       required: false
+
+  it 'should use derived package name', ->
+    module = integrations.modules['leadconduit-default.inbound']
+    assert.equal module.package.name, 'Default'
+
+  it 'should use specified package name', ->
+    integration = require('leadconduit-default')
+    original = integration.name
+    integration.name = 'Foo'
+    integrations.initPackage('leadconduit-default')
+    try
+      module = integrations.modules['leadconduit-default.inbound']
+      assert.equal module.package.name, 'Foo'
+    finally
+      integration.name = original
+


### PR DESCRIPTION
Currently the UI doesn't have a good way to show the full integration name. We discussed using the `name` property out of package.json. And in some cases that will work OK. But sometimes it would be best to allow the integration author to specify the package name explicitly.