### PR TITLE
update billsdotcom to ^1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "dotaccess": "^1.0.5",
     "leadconduit-autoresponder": "^0.1.0",
     "leadconduit-batchrobot": "~0.0.2",
-    "leadconduit-billsdotcom": "^0.3.0",
+    "leadconduit-billsdotcom": "^1.0.0",
     "leadconduit-briteverify": "^0.4.0",
     "leadconduit-cake": "~0.0.2",
     "leadconduit-calq": "~0.0.1",


### PR DESCRIPTION
[This test](https://github.com/activeprospect/leadconduit-integrations/blob/master/spec/modules-spec.coffee#L26) now fails after [this update](https://github.com/activeprospect/leadconduit-integration-default/pull/33/files). Should the test be changed to test a different module?