### PR TITLE
Gunzip response bodies as necessary

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -171,6 +171,10 @@ generateHandle = (outbound) ->
       # Ensure that timeout is set somewhere between minTimeout and maxTimeout and convert to milliseconds
       options.timeout = ensureTimeout(options.timeout ? vars.timeout_seconds) * 1000
 
+      # If the outbound integration accepts gzipped responses, then set the 'gzip' option to true
+      gzip = normalizeHeaders(outboundReq.headers || {})['Accept-Encoding']?.toLowerCase().indexOf('gzip') >= 0
+      options.gzip = gzip || false
+
       try
         request options, cb
       catch err


### PR DESCRIPTION
This ensures that the HTTP client uses the `gzip` option when the `Accept-Encoding` header contains "gzip". The gzip option causes the response body to be automatically gunzipped. This fixes an issue where the response parsing doesn't work because the response body is gzipped.